### PR TITLE
Fix linux download

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -41,7 +41,7 @@ helpers do
     when :windows
       "Bdash Setup #{bdash_version}.exe"
     when :linux
-      "Bdash-#{bdash_version}-x86_64.AppImage"
+      "Bdash-#{bdash_version}.AppImage"
     else
       raise ArgumentError, "Invalid platform: #{platform}"
     end


### PR DESCRIPTION
I noticed that the download for linux did not work, because `-x86_64` is not part of the filename.

https://bdash.global.ssl.fastly.net/v1.7.2/Bdash-1.7.2-x86_64.AppImage -> does not work

https://bdash.global.ssl.fastly.net/v1.7.2/Bdash-1.7.2.AppImage -> works